### PR TITLE
Refactor: `generateFolderPath` to generic function

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -191,7 +191,7 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('src/build')
+      expect(generateFolderPath(action, 'folder')).toEqual('src/build')
     })
 
     it('should return original path if folder name begins with /', () => {
@@ -205,7 +205,9 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
+      expect(generateFolderPath(action, 'folder')).toEqual(
+        '/home/user/repo/build'
+      )
     })
 
     it('should process as relative path if folder name begins with ./', () => {
@@ -219,7 +221,7 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('src/build')
+      expect(generateFolderPath(action, 'folder')).toEqual('src/build')
     })
 
     it('should return absolute path if folder name begins with ~', () => {
@@ -234,7 +236,9 @@ describe('util', () => {
         silent: false
       }
       process.env.HOME = '/home/user'
-      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
+      expect(generateFolderPath(action, 'folder')).toEqual(
+        '/home/user/repo/build'
+      )
     })
   })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export interface ActionInterface {
   /** The fully qualified repositpory path, this gets auto generated if repositoryName is provided. */
   repositoryPath?: string
   /** The root directory where your project lives. */
-  root?: string
+  root: string
   /** Wipes the commit history from the deployment branch in favor of a single commit. */
   singleCommit?: boolean | null
   /** Determines if the action should run in silent mode or not. */
@@ -108,6 +108,10 @@ export const action: ActionInterface = {
   targetFolder: getInput('TARGET_FOLDER'),
   workspace: process.env.GITHUB_WORKSPACE || ''
 }
+
+export type ActionFolders = NonNullable<
+  Pick<ActionInterface, 'folder' | 'root'>
+>
 
 /** Status codes for the action. */
 export enum Status {

--- a/src/git.ts
+++ b/src/git.ts
@@ -131,6 +131,8 @@ export async function generateBranch(action: ActionInterface): Promise<void> {
 
 /* Runs the necessary steps to make the deployment. */
 export async function deploy(action: ActionInterface): Promise<Status> {
+  const folderPath = generateFolderPath(action, 'folder')
+  const rootPath = generateFolderPath(action, 'root')
   const temporaryDeploymentDirectory =
     'github-pages-deploy-action-temp-deployment-folder'
   const temporaryDeploymentBranch = `github-pages-deploy-action/${Math.random()
@@ -229,7 +231,6 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       Pushes all of the build files into the deployment directory.
       Allows the user to specify the root if '.' is provided.
       rsync is used to prevent file duplication. */
-    const folderPath = generateFolderPath(action)
     await execute(
       `rsync -q -av --checksum --progress ${folderPath}/. ${
         action.targetFolder
@@ -246,7 +247,7 @@ export async function deploy(action: ActionInterface): Promise<Status> {
             }`
           : ''
       }  --exclude .ssh --exclude .git --exclude .github ${
-        folderPath === action.root
+        folderPath === rootPath
           ? `--exclude ${temporaryDeploymentDirectory}`
           : ''
       }`,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import {isDebug} from '@actions/core'
-import {ActionInterface} from './constants'
+import {ActionInterface, ActionFolders} from './constants'
 
 const replaceAll = (input: string, find: string, replace: string): string =>
   input.split(find).join(replace)
@@ -28,8 +28,11 @@ export const generateRepositoryPath = (action: ActionInterface): string =>
       }@github.com/${action.repositoryName}.git`
 
 /* Genetate absolute folder path by the provided folder name */
-export const generateFolderPath = (action: ActionInterface): string => {
-  const folderName = action.folder
+export const generateFolderPath = <K extends keyof ActionFolders>(
+  action: ActionInterface,
+  key: K
+): string => {
+  const folderName = action[key]
   const folderPath = path.isAbsolute(folderName)
     ? folderName
     : folderName.startsWith('~')


### PR DESCRIPTION
`action.root` is initialized at https://github.com/JamesIves/github-pages-deploy-action/blob/e42fda2d729c4fb61d3160e154aecf3fde4e8f6d/src/constants.ts#L98, so it should not be an optional property.

**Description**
> Provide a description of what your changes do.

Refactor `generateFolderPath` to generic function